### PR TITLE
Bug 4668: Correct typo

### DIFF
--- a/po/ca.po
+++ b/po/ca.po
@@ -216,7 +216,7 @@ msgid "Found <b>nothing</b> while searching for"
 msgstr ""
 
 #: ../templates/packages_area.html:24
-msgid "you probably mispelled it"
+msgid "you probably misspelled it"
 msgstr ""
 
 #: ../templates/packages_area.html:55

--- a/po/fr.po
+++ b/po/fr.po
@@ -216,7 +216,7 @@ msgid "Found <b>nothing</b> while searching for"
 msgstr ""
 
 #: ../templates/packages_area.html:24
-msgid "you probably mispelled it"
+msgid "you probably misspelled it"
 msgstr ""
 
 #: ../templates/packages_area.html:55

--- a/po/it.po
+++ b/po/it.po
@@ -218,7 +218,7 @@ msgid "Found <b>nothing</b> while searching for"
 msgstr ""
 
 #: ../templates/packages_area.html:24
-msgid "you probably mispelled it"
+msgid "you probably misspelled it"
 msgstr ""
 
 #: ../templates/packages_area.html:55

--- a/po/nl.po
+++ b/po/nl.po
@@ -216,7 +216,7 @@ msgid "Found <b>nothing</b> while searching for"
 msgstr ""
 
 #: ../templates/packages_area.html:24
-msgid "you probably mispelled it"
+msgid "you probably misspelled it"
 msgstr ""
 
 #: ../templates/packages_area.html:55

--- a/po/www.pot
+++ b/po/www.pot
@@ -209,7 +209,7 @@ msgid "Found <b>nothing</b> while searching for"
 msgstr ""
 
 #: ../templates/packages_area.html:24
-msgid "you probably mispelled it"
+msgid "you probably misspelled it"
 msgstr ""
 
 #: ../templates/packages_area.html:55

--- a/templates/packages_area.html
+++ b/templates/packages_area.html
@@ -21,7 +21,7 @@
     % endif
     % if c.did_you_mean:
         <div class="did-you-mean">
-            ${_("Found <b>nothing</b> while searching for")}: <b class="very-bold">${c.quick_search_string | h,trim}</b>, ${_("you probably mispelled it")}.
+            ${_("Found <b>nothing</b> while searching for")}: <b class="very-bold">${c.quick_search_string | h,trim}</b>, ${_("you probably misspelled it")}.
         </div>
         <hr class="packages-separator"/>
     % endif


### PR DESCRIPTION
It's "misspelled", not "mispelled"
See: <https://www.merriam-webster.com/dictionary/misspell>